### PR TITLE
Add Nuget.Core as dependency

### DIFF
--- a/Cake.ExtendedNuGet.nuspec
+++ b/Cake.ExtendedNuGet.nuspec
@@ -15,6 +15,11 @@
       <copyright>Copyright (c) Redth 2015-2016</copyright>
       <releaseNotes>Initial Release</releaseNotes>
       <tags>Cake Script Build</tags>
+
+      <dependencies>
+         <dependency id="Nuget.Core" version="2.14.0" />
+      </dependencies>
+
    </metadata>
 
    <files>


### PR DESCRIPTION
Started using this addon recently, and it's not immediately intuitive to have to include the Nuget.Core package. This adds it as a dependency in the nuspec so it won't be needed anymore.